### PR TITLE
Apply background-color except index.html in nav.

### DIFF
--- a/_includes/css/sotm2016.css
+++ b/_includes/css/sotm2016.css
@@ -547,3 +547,7 @@ input#mce-EMAIL::selection {
       left: 0px;
     }
 }
+
+.navbar-filter {
+    background-color: #78acdf;
+}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,5 +1,5 @@
  <!-- Navigation -->
-    <nav class="navbar navbar-custom navbar-fixed-top  {% if page.options contains "dark-nav" %} top-nav-collapse stay-collapsed {% endif %}" role="navigation">
+    <nav class="navbar navbar-custom navbar-fixed-top  {% if page.options contains "dark-nav" %} top-nav-collapse stay-collapsed {% endif %} {% if page.role != "index" %} navbar-filter {% endif %}" role="navigation">
         <div class="limiter">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+role: index
 ---
 
 


### PR DESCRIPTION
Apply background-color: #78acdf; except index.html in navbar.

https://github.com/openstreetmap/stateofthemap-2017/issues/27
Issue #27 

I apply bg-color except index.html, in nav. Because I wanted cherry blossoms at index.html to be visible.
Intentioned to change in minimum edit it.

Make index.html have a specific value(page.role="index").and Added Liquid to nav.html that add class to nav element when page.role != index.
Wrote the applicable CSS style.