### PR TITLE
Fix map link for Hotel Takakoh on Japanese page.

### DIFF
--- a/ja/venue/index.html
+++ b/ja/venue/index.html
@@ -24,7 +24,7 @@ title: 会場 &amp; 宿泊施設
          <ul>
             <li>住所:〒965-0872 福島県会津若松市東栄町3-35</li>
             <li>電話: 0242-27-7117</li>
-            <li><a href="https://www.openstreetmap.org/node/3705945507">Map</a></li>
+            <li><a href="https://www.openstreetmap.org/node/4840836907">Map</a></li>
          </ul>
          <h3><a href="http://www.fujigrandhotel.co.jp/">駅前フジグランドホテル</a></h3>
          <ul>


### PR DESCRIPTION
The old node has been deleted 11 days ago.
It was able to notice PR #48.