### PR TITLE
remove ::selection CSS pseudo-element

### DIFF
--- a/_includes/css/sotm2016.css
+++ b/_includes/css/sotm2016.css
@@ -338,18 +338,6 @@ footer p {
     margin: 0;
 }
 
-::-moz-selection {
-    text-shadow: none;
-    background: #fcfcfc;
-    background: rgba(255,255,255,.2);
-}
-
-::selection {
-    text-shadow: none;
-    background: #fcfcfc;
-    background: rgba(255,255,255,.2);
-}
-
 img::selection {
     background: 0 0;
 }


### PR DESCRIPTION
Japan team member wants to copy text from website, ::selection pseudo set background-color but this color is confusing when select text.
And it looks clear text-shadow, but ::-moz-selection will remove default color setting in Firefox ([related bug](https://bugzilla.mozilla.org/show_bug.cgi?id=234102)), so it can't use only clear text-shadow, so I make a proposal to remove it.