### PR TITLE
Add youtube videos for the first half of Friday

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -133,7 +133,7 @@ color: dark-nav
         </header>
         {% if page.youtube_recording %}
         <div class='prose space-bottom2'>
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ page.youtube_recording }}" frameborder="0" allowfullscreen></iframe>
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ page.youtube_recording }}{% if page.youtube_time %}?start={{ page.youtube_time }}{% endif %}" frameborder="0" allowfullscreen></iframe>
         </div>
         {% endif %}
         <div class='prose space-bottom2'>

--- a/_posts/schedule/0200-01-01-how-to-build-up-an-osm-community.md
+++ b/_posts/schedule/0200-01-01-how-to-build-up-an-osm-community.md
@@ -13,7 +13,8 @@ osm: AnissKoutsi
 room: Main hall
 tags:
   - slot2
-youtube_recording: 
+youtube_recording: PvMhlAcg8n4
+youtube_time: 1h22m40s
 ---
 In 2012 not a lot of people were interested in OpenStreetMap in the relatively small city of Tirana, the capital of Albania. In my talk I will share the story of how , a small but dedicated group of people, jump started the community in a small country like Albania and what other small cities and countries should avoid during their first steps in developing an OpenStreetMap community in similar conditions. Most important I will share tips and tricks on how to keep the mapathon spirit alive for a long time after the first enthusiastic steps, with the goal that our shared experience will help other communities to make the first steps or grow even further. Also another topic that influence the health of a community is also the aspect of diversity and inclusion for which I will talk a bit on how to keep them contributing and motivated.
 

--- a/_posts/schedule/0200-01-01-lightning-talks-1.md
+++ b/_posts/schedule/0200-01-01-lightning-talks-1.md
@@ -13,7 +13,7 @@ osm:
 room: Main hall
 tags:
   - slot3
-youtube_recording:
+youtube_recording: 87D7CpsAWn8
 ---
 "Join us on Friday for the following Lightning talks in the main hall:
 

--- a/_posts/schedule/0200-01-01-osm-in-aizuwakamatsu-city-construction-of-a-hazard-map.md
+++ b/_posts/schedule/0200-01-01-osm-in-aizuwakamatsu-city-construction-of-a-hazard-map.md
@@ -13,7 +13,8 @@ osm: jun_meguro
 room: Main hall
 tags:
   - slot1
-youtube_recording: 
+youtube_recording: PvMhlAcg8n4
+youtube_time: 56m20s
 ---
 Aizuwakamatsu city is one of the representative cities of Fukushima prefecture. In OpenStreetMap it is covered throughout by the community contribution. The administration of Aizuwakamatsu city used the OpenStreetMap data and other opendata to create a hazard map of sediment-related disasters, and distributed 50,000 paper maps to all households. The Aizu OSM community also has created its own hazard map. Jun Meguro will introduce the process until the hazard map is constructed.
 

--- a/_posts/schedule/0200-01-02-mapping-with-a-time-dimension.md
+++ b/_posts/schedule/0200-01-02-mapping-with-a-time-dimension.md
@@ -13,7 +13,8 @@ osm: daanvr
 room: Room 1
 tags:
   - slot3
-youtube_recording: 
+youtube_recording: aoT3FY_CTQc
+youtube_time: 1h33m20s
 ---
 I will speak about the progress I have made from last year’s lighting-talk at Brussels of a vision to start a non-profit startup aiming at making one unified map of the world history. Using the latest technologies like vector tiles to add a time dimension to every map tile. 
 I would also speak about the challenges of building a platform form scratch, build a community, to getting significant funding from local government, and much more.

--- a/_posts/schedule/0200-01-02-mobile-app-development-with-routing-and-voice-navigation.md
+++ b/_posts/schedule/0200-01-02-mobile-app-development-with-routing-and-voice-navigation.md
@@ -13,7 +13,8 @@ osm: smellman
 room: Room 1
 tags:
   - slot1
-youtube_recording: 
+youtube_recording: aoT3FY_CTQc
+youtube_time: 14m12s
 ---
 We developed an OpenStreetMap-driven smartphone application named "Daredemo Navi" for Kobe City's "Shiawase-no-Mura" (Village of Happiness) in Japan.
 "Shiawase-no-Mura" is a comprehensive welfare complex equipped with a variety of integrated facilities designed to support independent living for the disabled and the elderly.

--- a/_posts/schedule/0200-01-02-new-opportunities-for-understanding-the-ancient-coastline.md
+++ b/_posts/schedule/0200-01-02-new-opportunities-for-understanding-the-ancient-coastline.md
@@ -13,7 +13,8 @@ osm: andreougm
 room: Room 1
 tags:
   - slot4
-youtube_recording: 
+youtube_recording: aoT3FY_CTQc
+youtube_time: 2h02m00s
 ---
 Coastal erosion is a landscape alteration process that affects areas throughout the world. In terms of cultural heritage management, the erosion-induced loss of land is an obstacle to our still emerging understanding of ancient coastlines, maritime trade and human interaction. Although measures have been taken to quantify land-loss and protect actively eroding areas, a key question remains: how can we monitor the exposure of previously unknown archaeological sites in a time- and cost-effective manner? 
 

--- a/_posts/schedule/0200-01-02-photo-walk-in-aizuwakamatsu.md
+++ b/_posts/schedule/0200-01-02-photo-walk-in-aizuwakamatsu.md
@@ -13,6 +13,7 @@ osm:
 room: Room 1
 tags:
   - slot2
-youtube_recording: 
+youtube_recording: aoT3FY_CTQc
+youtube_time: 41m25m
 ---
 Join Edoardo from Mapillary for a photo walk around the grounds of Aizuwakamatsu Castle. We'll break into groups and cover different routes as we learn how to use the app, action cams and 360º cams. If time permits we'll try uploading as well. Download the Mapillary app to your device before the event and take the opportunity to stretch your legs around this historic venue. We'll be meeting at 11am in Room 1 of Aizuwakamatsu City Culture Centre. The walk itself should take only 20 minutes, after which we can come back and upload the imagery through the day.


### PR DESCRIPTION
So I had to add an extra parameter to specify starting time for the youtube videos. I added videos to first six talks (that's three recordings from the SotM video channel) to test the feature.

But there was an unexpected issue. Please allow embedding the videos on their settings pages. Otherwise we cannot use these in the SotM website.